### PR TITLE
chore: readme fix devDeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Run the following command to add `unjwt` to your project.
 
 ```bash
 # pnpm
-pnpm add -D unjwt
+pnpm add unjwt
 
 # npm
-npm install -D unjwt
+npm install unjwt
 
 # yarn
-yarn add -D unjwt
+yarn add unjwt
 ```
 
 ## Usage


### PR DESCRIPTION
-D is for devDependencies, so for dependencies that have development purpose, but jwt checking would definitely be a production function? or am I wrong?